### PR TITLE
Fixed failing test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+tests/tmp

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,4 +1,8 @@
 var test = require('tape');
+
+var child_process = require('child_process');
+var fs = require('fs');
+
 var jiraLinker = require('../index').file;
 var jiraFolderLinker = require('../index').folder;
 
@@ -11,190 +15,171 @@ var jiraFolderLinker = require('../index').folder;
 
 
 function setUp() {
-	var child_process = require('child_process');
 	child_process.spawnSync("rm", ["-rf", "tmp"], {"cwd": __dirname});
 	child_process.spawnSync("mkdir", ["tmp"], {"cwd": __dirname});
 	process.chdir(__dirname + "/tmp");
-	}
-
-function cleanUp() {
-	var child_process = require('child_process');
-	child_process.spawn("rm", ["-rf", "tmp"], {"cwd": __dirname});
-	process.chdir(__dirname + "/..");
-
 }
 
 test('single line', function (t) {
-	var fs = require('fs');
 	t.plan(3);
 	setTimeout(function() {
 		setUp();
-		var sh = require("shelljs");
 		fs.writeFile("test.md", "* CB-1234 Testing line 1234", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("test.md", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("test.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker")
-				   	}
-		    	});
-		    }
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("test.md", function(err, file) {
+                    if (!err) {
+                        fs.readFile("test.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker");
+                    }
+                });
+            }
 		});
 		fs.writeFile("test1.md", "* [CB-1234] Testing line 1234", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("test1.md", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("test1.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker")
-				   	}
-		    	});
-		    }
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("test1.md", function(err, file) {
+                    if (!err) {
+                        fs.readFile("test1.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker");
+                    }
+                });
+            }
 		});
 		fs.writeFile("test2.md", "* CB-10096: Upgrading to Gradle Plugin 2.1.0", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("test2.md", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("test2.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [CB-10096](https://issues.apache.org/jira/browse/CB-10096) Upgrading to Gradle Plugin 2.1.0"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker")
-				   	}
-		    	});
-		    }
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("test2.md", function(err, file) {
+                    if (!err) {
+                        fs.readFile("test2.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [CB-10096](https://issues.apache.org/jira/browse/CB-10096) Upgrading to Gradle Plugin 2.1.0");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker");
+                    }
+                });
+            }
 		});
-	}, 200); 
+	}, 200);
 });
 
 test('one file in current folder, second file in deep folder', function (t) {
-	var fs = require('fs');
 	t.plan(2);
-	
+
 	setTimeout(function() {
 		setUp();
 		fs.writeFile("test.md", "* [AA-1234] Testing line 1234", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("test.md", "AA", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("test.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [AA-1234](https://issues.apache.org/jira/browse/AA-1234) Testing line 1234"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker on current level")
-				   	}
-		    	});
-		    }
-		});
-		var child_process = require('child_process');
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("test.md", "AA", function(err, file) {
+                    if (!err) {
+                        fs.readFile("test.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [AA-1234](https://issues.apache.org/jira/browse/AA-1234) Testing line 1234");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker on current level");
+                    }
+                });
+            }
+        });
 		child_process.spawnSync("mkdir", ["tmp/tmp1"], {"cwd": __dirname});
 		fs.writeFile("tmp1/test.md", "* [CB-1234] Testing line 1234", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("tmp1/test.md", "CB", function(err) {
-		    		if (!err) {
-				    	fs.readFile("tmp1/test.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker on deeper level")
-				   	}
-		    	});
-		    }
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("tmp1/test.md", "CB", function(err) {
+                    if (!err) {
+                        fs.readFile("tmp1/test.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker on deeper level")
+                    }
+                });
+            }
 		});
-	}, 400); 
+	}, 400);
 });
 
 test('calling on a file one level up', function (t) {
-	var fs = require('fs');
 	t.plan(1);
 	setTimeout(function() {
 		setUp();
 		fs.writeFile("test.md", "* [CB-1234] Testing line 1234", function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	var child_process = require('child_process');
-				child_process.spawn("mkdir", ["tmp/tmp1"], {"cwd": __dirname});
+            if (err) {
+                return t.error(err);
+            } else {
+				child_process.spawnSync("mkdir", ["tmp/tmp1"], {"cwd": __dirname});
 				process.chdir(__dirname + "/tmp/tmp1");
-		    	jiraLinker("../test.md", "CB", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("../test.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, 
-				    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234"); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker on current level")
-				   	}
-		    	});
-		    }
+                jiraLinker("../test.md", "CB", function(err, file) {
+                    if (!err) {
+                        fs.readFile("../test.md", 'utf8', function(err, contents) {
+                            t.equal(contents,
+                                "* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234");
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker on current level");
+                    }
+                });
+            }
 		});
-	}, 400); 
+	}, 400);
 });
 
 
 test('Many lines', function (t) {
+    var linesIn = "* CB-8320 Setting up gradle so we can use CordovaLib as a standard Android Library\n\
+    * CB-8328 Allow plugins to handle certificate challenges (close #150)\n\
+    * CB-8329 Cancel outstanding ActivityResult requests when a new startActivityForResult occurs\n\
+    * CB-8378 Removed `hidekeyboard` and `showkeyboard` events (apps should use a plugin instead)";
 
-var linesIn = "* CB-8320 Setting up gradle so we can use CordovaLib as a standard Android Library\n\
-* CB-8328 Allow plugins to handle certificate challenges (close #150)\n\
-* CB-8329 Cancel outstanding ActivityResult requests when a new startActivityForResult occurs\n\
-* CB-8378 Removed `hidekeyboard` and `showkeyboard` events (apps should use a plugin instead)";
+    var linesOut = "* [CB-8320](https://issues.apache.org/jira/browse/CB-8320) Setting up gradle so we can use CordovaLib as a standard Android Library\n\
+    * [CB-8328](https://issues.apache.org/jira/browse/CB-8328) Allow plugins to handle certificate challenges (close #150)\n\
+    * [CB-8329](https://issues.apache.org/jira/browse/CB-8329) Cancel outstanding ActivityResult requests when a new startActivityForResult occurs\n\
+    * [CB-8378](https://issues.apache.org/jira/browse/CB-8378) Removed `hidekeyboard` and `showkeyboard` events (apps should use a plugin instead)";
 
-var linesOut = "* [CB-8320](https://issues.apache.org/jira/browse/CB-8320) Setting up gradle so we can use CordovaLib as a standard Android Library\n\
-* [CB-8328](https://issues.apache.org/jira/browse/CB-8328) Allow plugins to handle certificate challenges (close #150)\n\
-* [CB-8329](https://issues.apache.org/jira/browse/CB-8329) Cancel outstanding ActivityResult requests when a new startActivityForResult occurs\n\
-* [CB-8378](https://issues.apache.org/jira/browse/CB-8378) Removed `hidekeyboard` and `showkeyboard` events (apps should use a plugin instead)";
-
-	var fs = require('fs');
 	t.plan(1);
 	setUp();
 	setTimeout(function() {
 		fs.writeFile("test.md", linesIn, function(err) {
-		    if(err) {
-		        return t.error(err);
-		    } else{
-		    	jiraLinker("test.md", "CB", function(err, file) {
-		    		if (!err) {
-				    	fs.readFile("test.md", 'utf8', function(err, contents) {
-				    		t.equal(contents, linesOut); 
-				    	});
-				   	} else {
-				   		t.fail("Error calling jiraLinker")
-				   	}
-		    	});
-		    }
-		});
-	}, 2000); 
-
+            if (err) {
+                return t.error(err);
+            } else {
+                jiraLinker("test.md", "CB", function(err, file) {
+                    if (!err) {
+                        fs.readFile("test.md", 'utf8', function(err, contents) {
+                            t.equal(contents, linesOut);
+                        });
+                    } else {
+                        t.fail("Error calling jiraLinker");
+                    }
+                });
+            }
+        });
+	}, 2000);
 });
 
 // Couldn't write tests :(
 // test('files in a folder', function (t) {
-// 	var fs = require('fs');
 // 	t.plan(3);
-	
+
 // 	setTimeout(function() {
 // 		setUp();
-// 		var child_process = require('child_process');
 // 		child_process.spawnSync("mkdir", ["tmp/tmp2"], {"cwd": __dirname});
 // 		fs.writeFileSync("tmp2/test1.md", "* [CB-1234] Testing line 1234");
 // 		fs.writeFileSync("tmp2/test2.md", "* [CB-1234] Testing line 1234");
@@ -203,19 +188,16 @@ var linesOut = "* [CB-8320](https://issues.apache.org/jira/browse/CB-8320) Setti
 // 					console.log(fileArray);
 // 				    for (var i = 0; i < fileArray; i++) {
 // 							fs.readFile(fileArray[i], 'utf8', function(err, contents) {
-// 					    		t.equal(contents, 
-// 					    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234"); 
+// 					    		t.equal(contents,
+// 					    			"* [CB-1234](https://issues.apache.org/jira/browse/CB-1234) Testing line 1234");
 // 					    	});
-// 					} 
+// 					}
 // 		    	});
-		
-// 	}, 10000); 
+
+// 	}, 10000);
 // });
 
-
-
-
-test('clean up [NOT A TEST]', function(t) {
-	cleanUp();
-	t.end();
+test.onFinish(function() {
+	child_process.spawn("rm", ["-rf", "tmp"], {"cwd": __dirname});
+	process.chdir(__dirname + "/..");
 });


### PR DESCRIPTION
1. Tests were failing due to an invocation of `spawn` instead of `spawnSync`. Fixed that.
2. Made consistent the use of mixed identation/spacing and use of semicolons in the tests.
3. Added the tests/tmp directory to gitignore.
4. Use tape's onFinish method as a global cleanup hook for the tests, rather than explicitly specifying another test.

Also of note: the npm-released version is at 2.2.3. However, the repository's version here is at 2.2.2. Was there perhaps some code that got released out that did not make it back into this GitHub repo?